### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/src/dev/wandb/run-20240803_213258-cfgh2a8s/files/requirements.txt
+++ b/src/dev/wandb/run-20240803_213258-cfgh2a8s/files/requirements.txt
@@ -514,7 +514,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pycairo==1.20.1
 pycoingecko==3.1.0
 pycparser==2.21

--- a/src/dev/wandb/run-20240818_224205-xalliuvg/files/requirements.txt
+++ b/src/dev/wandb/run-20240818_224205-xalliuvg/files/requirements.txt
@@ -517,7 +517,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pycairo==1.20.1
 pycoingecko==3.1.0
 pycparser==2.21

--- a/src/dev/wandb/run-20240824_223732-e9bvqoct/files/requirements.txt
+++ b/src/dev/wandb/run-20240824_223732-e9bvqoct/files/requirements.txt
@@ -519,7 +519,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pycairo==1.20.1
 pycoingecko==3.1.0
 pycparser==2.21

--- a/src/dev/wandb/run-20240824_234005-fzlxn0s0/files/requirements.txt
+++ b/src/dev/wandb/run-20240824_234005-fzlxn0s0/files/requirements.txt
@@ -520,7 +520,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pycairo==1.20.1
 pycoingecko==3.1.0
 pycparser==2.21

--- a/src/dev/wandb/run-20250218_001550-uru5pry8/files/requirements.txt
+++ b/src/dev/wandb/run-20250218_001550-uru5pry8/files/requirements.txt
@@ -608,7 +608,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pybind11==2.13.6
 pycairo==1.20.1
 pyclipper==1.3.0.post6

--- a/src/dev/wandb/run-20250218_222111-fg6gjr4x/files/requirements.txt
+++ b/src/dev/wandb/run-20250218_222111-fg6gjr4x/files/requirements.txt
@@ -608,7 +608,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pybind11==2.13.6
 pycairo==1.20.1
 pyclipper==1.3.0.post6

--- a/src/dev/wandb/run-20250218_224834-lidshcih/files/requirements.txt
+++ b/src/dev/wandb/run-20250218_224834-lidshcih/files/requirements.txt
@@ -608,7 +608,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pybind11==2.13.6
 pycairo==1.20.1
 pyclipper==1.3.0.post6

--- a/src/dev/wandb/run-20250218_225246-450wzuf6/files/requirements.txt
+++ b/src/dev/wandb/run-20250218_225246-450wzuf6/files/requirements.txt
@@ -608,7 +608,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pybind11==2.13.6
 pycairo==1.20.1
 pyclipper==1.3.0.post6

--- a/src/dev/wandb/run-20250218_231729-jogf7k5d/files/requirements.txt
+++ b/src/dev/wandb/run-20250218_231729-jogf7k5d/files/requirements.txt
@@ -608,7 +608,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pybind11==2.13.6
 pycairo==1.20.1
 pyclipper==1.3.0.post6

--- a/src/dev/wandb/run-20250224_232738-mvmtf7uy/files/requirements.txt
+++ b/src/dev/wandb/run-20250224_232738-mvmtf7uy/files/requirements.txt
@@ -633,7 +633,7 @@ pyarrow==16.1.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
 pyasn1==0.4.8
-pyautogen==0.2.9
+ag2==0.2.9
 pybind11==2.13.6
 pycairo==1.20.1
 pyclipper==1.3.0.post6

--- a/src/new-requirements.txt
+++ b/src/new-requirements.txt
@@ -602,7 +602,7 @@ pyarrow==16.1.0
 pyarrow-hotfix==0.6
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pyautogen==0.2.9
+ag2==0.2.9
 pybind11==2.13.6
 PyBluez==0.23
 pycairo==1.20.1


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
